### PR TITLE
added clone to Fft and FFTConvolver type

### DIFF
--- a/src/fft.rs
+++ b/src/fft.rs
@@ -2,6 +2,7 @@ use realfft::{ComplexToReal, FftError, RealFftPlanner, RealToComplex};
 use rustfft::{num_complex::Complex, FftNum};
 use std::sync::Arc;
 
+#[derive(Clone)]
 pub struct Fft<F: FftNum> {
     fft_forward: Arc<dyn RealToComplex<F>>,
     fft_inverse: Arc<dyn ComplexToReal<F>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ pub enum FFTConvolverProcessError {
 ///   "unpredictable" operations like allocations, locking, API calls, etc. are
 ///   performed during processing (all necessary allocations and preparations take
 ///   place during initialization).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FFTConvolver<F: FftNum> {
     ir_len: usize,
     block_size: usize,


### PR DESCRIPTION
Hello, thank you for providing this crate.

In many cases, i would like to store a Vec of convolvers. In idiomatic rust, this would ideally look like:

```
vec![FFTConvolver::default(); 16]
```

However, this is not possible as `FFTConvolver` does not implement clone. This PR implements `Clone` for `FFTConvolver`, and underlying type `Fft`, enabling the above behavior. This should have no consequence on user API.