### PR TITLE
derive Debug on public types

### DIFF
--- a/src/fft.rs
+++ b/src/fft.rs
@@ -1,7 +1,7 @@
 use realfft::num_complex::Complex;
 use realfft::{ComplexToReal, FftError, FftNum, RealFftPlanner, RealToComplex};
 use rtsan_standalone::nonblocking;
-use std::sync::Arc;
+use std::{fmt, sync::Arc};
 
 #[derive(Clone)]
 pub struct Fft<F: FftNum> {
@@ -9,6 +9,15 @@ pub struct Fft<F: FftNum> {
     scratch_forward: Vec<Complex<F>>,
     fft_inverse: Arc<dyn ComplexToReal<F>>,
     scratch_inverse: Vec<Complex<F>>,
+}
+
+impl<F: FftNum + fmt::Debug> fmt::Debug for Fft<F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Fft")
+            .field("scratch_forward", &self.scratch_forward)
+            .field("scratch_inverse", &self.scratch_inverse)
+            .finish_non_exhaustive()
+    }
 }
 
 impl<F: FftNum> Default for Fft<F> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_debug_implementations)]
 #![doc = include_str!("../README.md")]
 
 mod fft;
@@ -37,7 +38,7 @@ pub enum FFTConvolverError {
 ///   "unpredictable" operations like allocations, locking, API calls, etc. are
 ///   performed during processing (all necessary allocations and preparations take
 ///   place during initialization).
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct FFTConvolver<F: FftNum> {
     ir_len: usize,
     block_size: usize,


### PR DESCRIPTION
when using `#[derive(Debug)]` in my codebase, I found out that some of `fft-convolver`'s structs were missing their own implementation of `Debug`. it is [considered good practice](https://doc.rust-lang.org/std/fmt/index.html#fmtdisplay-vs-fmtdebug) to have an impl for public types, and there is even [a rustc lint for it](https://doc.rust-lang.org/stable/nightly-rustc/rustc_lint/builtin/static.MISSING_DEBUG_IMPLEMENTATIONS.html).

this PR derives Debug where needed and enable the related lint.