### PR TITLE
Release 0.4.0

### DIFF
--- a/.github/workflows/compatability.yml
+++ b/.github/workflows/compatability.yml
@@ -1,4 +1,4 @@
-name: 🧰 Compatibility
+name: Compatibility
 
 on:
   push:
@@ -13,7 +13,7 @@ env:
 
 jobs:
   nightly:
-    name: 🌙 Nightly Rust
+    name: Nightly Rust
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -21,7 +21,7 @@ jobs:
       - run: cargo test --locked --all-features --all-targets --workspace
 
   update:
-    name: 🔄 Latest Dependencies
+    name: Latest Dependencies
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/compatability.yml
+++ b/.github/workflows/compatability.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
-      - run: sudo apt-get install -y libasound2-dev
+      - run: sudo apt-get install -y libasound2-dev libpulse-dev pkg-config cmake
       - run: cargo test --locked --all-features --all-targets --workspace
 
   update:
@@ -27,6 +27,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@beta
-      - run: sudo apt-get install -y libasound2-dev
+      - run: sudo apt-get install -y libasound2-dev libpulse-dev pkg-config cmake
       - run: cargo update
       - run: RUSTFLAGS="-D deprecated" cargo test --locked --all-features --all-targets --workspace

--- a/.github/workflows/compatability.yml
+++ b/.github/workflows/compatability.yml
@@ -18,6 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
+      - run: sudo apt-get install -y libasound2-dev
       - run: cargo test --locked --all-features --all-targets --workspace
 
   update:
@@ -26,5 +27,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@beta
+      - run: sudo apt-get install -y libasound2-dev
       - run: cargo update
       - run: RUSTFLAGS="-D deprecated" cargo test --locked --all-features --all-targets --workspace

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -70,5 +70,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.85.0
+          toolchain: 1.87.0
       - run: cargo check --all-features

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,4 +1,4 @@
-name: 🛡️ Quality Checks
+name: Quality Checks
 
 on:
   push:
@@ -11,7 +11,7 @@ env:
 
 jobs:
   cargo-fmt:
-    name: 📝 Code Format
+    name: Code Format
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -21,7 +21,7 @@ jobs:
       - run: cargo fmt --check
 
   taplo-fmt:
-    name: 📄 TOML Format
+    name: TOML Format
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -29,7 +29,7 @@ jobs:
       - run: taplo fmt --check
 
   clippy:
-    name: 📎 Clippy
+    name: Clippy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
       - run: RUSTFLAGS="-D warnings" cargo clippy
 
   doc:
-    name: 📚 Documentation
+    name: Documentation
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -47,7 +47,7 @@ jobs:
       - run: RUSTDOCFLAGS="-D warnings" cargo doc --locked --document-private-items
 
   semver:
-    name: 🏷️ Semver Checks
+    name: Semver Checks
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -55,7 +55,7 @@ jobs:
       - uses: obi1kenobi/cargo-semver-checks-action@v2
 
   hack:
-    name: 🧩 Feature Matrix
+    name: Feature Matrix
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -64,7 +64,7 @@ jobs:
       - run: cargo hack --feature-powerset check
 
   msrv:
-    name: 🏗️ MSRV Check
+    name: MSRV Check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -36,6 +36,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+      - run: sudo apt-get install -y libasound2-dev libpulse-dev pkg-config cmake
       - run: RUSTFLAGS="-D warnings" cargo clippy
 
   doc:
@@ -44,6 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - run: sudo apt-get install -y libasound2-dev libpulse-dev pkg-config cmake
       - run: RUSTDOCFLAGS="-D warnings" cargo doc --locked --document-private-items
 
   semver:
@@ -52,6 +54,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - run: sudo apt-get install -y libasound2-dev libpulse-dev pkg-config cmake
       - uses: obi1kenobi/cargo-semver-checks-action@v2
 
   hack:
@@ -60,6 +63,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - run: sudo apt-get install -y libasound2-dev libpulse-dev pkg-config cmake
       - uses: taiki-e/install-action@cargo-hack
       - run: cargo hack --feature-powerset check
 
@@ -71,4 +75,5 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.87.0
+      - run: sudo apt-get install -y libasound2-dev libpulse-dev pkg-config cmake
       - run: cargo check --all-features

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,9 @@ jobs:
           fi
           echo "Version verified: $TAG_VERSION"
 
+      - name: Install system dependencies
+        run: sudo apt-get install -y libasound2-dev libpulse-dev pkg-config cmake
+
       - name: Run tests
         run: cargo test --all-features
 

--- a/.github/workflows/safety.yml
+++ b/.github/workflows/safety.yml
@@ -1,4 +1,4 @@
-name: 🧹 Safety Checks
+name: Safety Checks
 
 on:
   push:
@@ -11,7 +11,7 @@ env:
 
 jobs:
   sanitizers:
-    name: 🩸 Leak and 🔍 Address Sanitizers
+    name: Leak and Address Sanitizers
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -41,7 +41,7 @@ jobs:
           RUSTFLAGS: "-Z sanitizer=leak"
 
   miri:
-    name: 🔮 Miri UB Checker
+    name: Miri UB Checker
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/safety.yml
+++ b/.github/workflows/safety.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
       - run: |
           # to get the symbolizer for debug symbol resolution
-          sudo apt install llvm
+          sudo apt install llvm libasound2-dev libpulse-dev pkg-config cmake
           # to fix buggy leak analyzer:
           # https://github.com/japaric/rust-san#unrealiable-leaksanitizer
           # ensure there's a profile.dev section

--- a/.github/workflows/safety.yml
+++ b/.github/workflows/safety.yml
@@ -51,4 +51,5 @@ jobs:
         with:
           toolchain: ${{ env.NIGHTLY }}
           components: miri
+      - run: sudo apt-get install -y libasound2-dev libpulse-dev pkg-config cmake
       - run: cargo miri test --lib --bins --tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Install ALSA dev (Linux only)
         if: runner.os == 'Linux'
-        run: sudo apt-get install -y libasound2-dev
+        run: sudo apt-get install -y libasound2-dev libpulse-dev pkg-config cmake
       - run: cargo test --locked --all-features --all-targets --workspace
         env:
           RTSAN_ENABLE: 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Install ALSA dev (Linux only)
+        if: runner.os == 'Linux'
+        run: sudo apt-get install -y libasound2-dev
       - run: cargo test --locked --all-features --all-targets --workspace
         env:
           RTSAN_ENABLE: 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: 🧪 Tests
+name: Tests
 
 on:
   push:
@@ -11,7 +11,7 @@ env:
 
 jobs:
   test:
-    name: 🧪 Full Test Suite on ${{ matrix.os }}
+    name: Full Test Suite on ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,10 +39,105 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "audio-blocks"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80b1cdb3f5e2e8434dd3fdd1f699d755728b9e1d4b4d0205f95bf91619283d47"
+dependencies = [
+ "rtsan-standalone",
+]
+
+[[package]]
+name = "audio-core"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ebbf82d06013f4c41fe71303feb980cddd78496d904d06be627972de51a24"
+
+[[package]]
+name = "audio-file"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9f77a84fa9b098dc8b9ab8c4e51a55dc9aa0e555e84382336d5409b0802019"
+dependencies = [
+ "approx",
+ "audioadapter-buffers",
+ "hound",
+ "num",
+ "rubato",
+ "symphonia",
+ "thiserror",
+]
+
+[[package]]
+name = "audio-host"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c032489f739e3a4afdfd6be04242eec0087f42c48feaf4d3fba112a35749592"
+dependencies = [
+ "audio-blocks",
+ "rtaudio",
+ "rtrb",
+ "thiserror",
+]
+
+[[package]]
+name = "audioadapter"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98e72b98fa467adcb7a88c5d1b8b686193185c81b9bf9c3fa3ac3524180cd55c"
+dependencies = [
+ "audio-core",
+ "libm",
+ "num-traits",
+]
+
+[[package]]
+name = "audioadapter-buffers"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6af89882334c4e501faa08992888593ada468f9e1ab211635c32f9ada7786e0"
+dependencies = [
+ "audioadapter",
+ "audioadapter-sample",
+ "num-traits",
+]
+
+[[package]]
+name = "audioadapter-sample"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e9a3d502fec0b21aa420febe0b110875cf8a7057c49e83a0cace1df6a73e03e"
+dependencies = [
+ "audio-core",
+ "num-traits",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -55,6 +150,12 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "cast"
@@ -131,6 +232,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "criterion"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,6 +313,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -219,6 +338,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "extended"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,6 +353,9 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 name = "fft-convolver"
 version = "0.4.0"
 dependencies = [
+ "audio-blocks",
+ "audio-file",
+ "audio-host",
  "criterion",
  "realfft",
  "rtsan-standalone",
@@ -322,6 +450,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hound"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,6 +500,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -376,6 +516,12 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
@@ -396,6 +542,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,6 +580,28 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -459,6 +651,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plotters"
@@ -590,6 +788,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rtaudio"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7384a8837efe4abea0e53f3887b5072cbbd1ee95c298cff4fbd7a9f3ff23a48b"
+dependencies = [
+ "bitflags 2.13.0",
+ "rtaudio-sys",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "rtaudio-sys"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "931ec9a72c48e96e8e2f9868aef1d4e452723354779d01159f7399647427b57b"
+dependencies = [
+ "cmake",
+ "pkg-config",
+]
+
+[[package]]
+name = "rtrb"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ade083ccbb4bf536df69d1f6432cc23deb7acccff86b183f3923a6fd56a1153"
+
+[[package]]
 name = "rtsan-standalone"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,6 +846,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rubato"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90173154a8a14e6adb109ea641743bc95ec81c093d94e70c6763565f7108ebeb"
+dependencies = [
+ "audioadapter",
+ "audioadapter-buffers",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "realfft",
+ "visibility",
+ "windowfunctions",
+]
+
+[[package]]
 name = "rustfft"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,7 +881,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -729,6 +971,201 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
+name = "symphonia"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5773a4c030a19d9bfaa090f49746ff35c75dfddfa700df7a5939d5e076a57039"
+dependencies = [
+ "lazy_static",
+ "symphonia-bundle-flac",
+ "symphonia-bundle-mp3",
+ "symphonia-codec-aac",
+ "symphonia-codec-adpcm",
+ "symphonia-codec-alac",
+ "symphonia-codec-pcm",
+ "symphonia-codec-vorbis",
+ "symphonia-core",
+ "symphonia-format-caf",
+ "symphonia-format-isomp4",
+ "symphonia-format-mkv",
+ "symphonia-format-ogg",
+ "symphonia-format-riff",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-bundle-flac"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91565e180aea25d9b80a910c546802526ffd0072d0b8974e3ebe59b686c9976"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-bundle-mp3"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4872dd6bb56bf5eac799e3e957aa1981086c3e613b27e0ac23b176054f7c57ed"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-codec-aac"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c263845aa86881416849c1729a54c7f55164f8b96111dba59de46849e73a790"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-adpcm"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dddc50e2bbea4cfe027441eece77c46b9f319748605ab8f3443350129ddd07f"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-alac"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8413fa754942ac16a73634c9dfd1500ed5c61430956b33728567f667fdd393ab"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-pcm"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e89d716c01541ad3ebe7c91ce4c8d38a7cf266a3f7b2f090b108fb0cb031d95"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-vorbis"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f025837c309cd69ffef572750b4a2257b59552c5399a5e49707cc5b1b85d1c73"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-core"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea00cc4f79b7f6bb7ff87eddc065a1066f3a43fe1875979056672c9ef948c2af"
+dependencies = [
+ "arrayvec",
+ "bitflags 1.3.2",
+ "bytemuck",
+ "lazy_static",
+ "log",
+]
+
+[[package]]
+name = "symphonia-format-caf"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8faf379316b6b6e6bbc274d00e7a592e0d63ff1a7e182ce8ba25e24edd3d096"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-format-isomp4"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "243739585d11f81daf8dac8d9f3d18cc7898f6c09a259675fc364b382c30e0a5"
+dependencies = [
+ "encoding_rs",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-mkv"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "122d786d2c43a49beb6f397551b4a050d8229eaa54c7ddf9ee4b98899b8742d0"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-ogg"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b4955c67c1ed3aa8ae8428d04ca8397fbef6a19b2b051e73b5da8b1435639cb"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-riff"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d7c3df0e7d94efb68401d81906eae73c02b40d5ec1a141962c592d0f11a96f"
+dependencies = [
+ "extended",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-metadata"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36306ff42b9ffe6e5afc99d49e121e0bd62fe79b9db7b9681d48e29fa19e6b16"
+dependencies = [
+ "encoding_rs",
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-utils-xiph"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27c85ab799a338446b68eec77abf42e1a6f1bb490656e121c6e27bfbab9f16"
+dependencies = [
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,6 +1220,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "transpose"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -803,6 +1271,17 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "visibility"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "walkdir"
@@ -905,7 +1384,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -951,6 +1430,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windowfunctions"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90628d739333b7c5d2ee0b70210b97b8cddc38440c682c96fd9e2c24c2db5f3a"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "windows-link"
@@ -1031,7 +1519,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.13.0",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,22 +3,210 @@
 version = 4
 
 [[package]]
-name = "autocfg"
-version = "1.5.0"
+name = "aho-corasick"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cc"
+version = "1.2.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -32,30 +220,100 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fft-convolver"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
+ "criterion",
  "realfft",
  "rtsan-standalone",
  "thiserror",
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.3.4"
+name = "find-msvc-tools"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
  "wasip2",
+ "wasip3",
 ]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -64,16 +322,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
-name = "libc"
-version = "0.2.177"
+name = "id-arena"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "log"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+
+[[package]]
+name = "memchr"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "num-complex"
@@ -114,9 +434,69 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "primal-check"
@@ -129,27 +509,47 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "realfft"
@@ -159,6 +559,35 @@ checksum = "f821338fddb99d089116342c46e9f1fbf3828dba077674613e734e01d6ea8677"
 dependencies = [
  "rustfft",
 ]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rtsan-standalone"
@@ -206,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
@@ -218,6 +647,82 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "strength_reduce"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,9 +730,9 @@ checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "syn"
-version = "2.0.111"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -236,9 +741,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom",
@@ -249,22 +754,32 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -279,18 +794,163 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e0871acf327f283dc6da28a1696cdc64fb355ba9f935d052021fa77f35cce69"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -309,6 +969,120 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fft-convolver"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 authors = ["Stephan Eckes <stephan@neodsp.com>"]
 description = "Audio convolution algorithm in pure Rust for real time audio processing"
@@ -10,7 +10,7 @@ keywords = ["audio", "filter", "convolution", "fft", "dsp"]
 categories = ["multimedia::audio"]
 readme = "README.md"
 homepage = "https://neodsp.com/"
-rust-version = "1.85"
+rust-version = "1.87"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -18,3 +18,10 @@ rust-version = "1.85"
 realfft = "3.5.0"
 thiserror = "2.0"
 rtsan-standalone = "0.3.0"
+
+[dev-dependencies]
+criterion = "0.8"
+
+[[bench]]
+name = "convolver"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ rtsan-standalone = "0.3.0"
 
 [dev-dependencies]
 criterion = "0.8"
+audio-file = "0.4"
+audio-host = "0.1"
+audio-blocks = "0.7"
 
 [[bench]]
 name = "convolver"

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ Perfect for real-time audio applications like convolution reverbs, cabinet simul
 
 ## How it Works
 
-The convolver uses a partitioned FFT convolution algorithm that divides the impulse response into uniform blocks. This approach provides:
+Both convolvers use a partitioned FFT convolution algorithm that divides the impulse response into blocks and accumulates results via overlap-add.
 
-- Consistent processing time regardless of buffer size
-- Efficient computation through FFT
-- Low latency suitable for real-time audio
+**`FFTConvolver`** uses uniform block sizes, giving consistent per-block processing time and predictable latency. It is the simpler of the two and works well for short-to-medium IRs.
+
+**`TwoStageFFTConvolver`** uses two block sizes: a small "head" block for low-latency processing of the early IR, and a large "tail" block for efficient processing of the late IR. This keeps latency low while reducing the total number of FFT operations for long IRs (see [Benchmarks](#benchmarks)).
 
 All memory allocation happens during initialization (`init()`), making subsequent processing (`process()`) completely allocation-free and suitable for real-time audio threads.
 
@@ -60,6 +60,25 @@ let ir2 = vec![0.8, 0.6, 0.4];
 convolver.set_response(&ir2).unwrap();
 ```
 
+### TwoStageFFTConvolver
+
+For long IRs, use `TwoStageFFTConvolver`. `init_default` automatically computes the optimal tail block size:
+
+```rust
+use fft_convolver::TwoStageFFTConvolver;
+
+let ir = vec![0.5_f32; 65_536];
+
+let mut convolver = TwoStageFFTConvolver::default();
+convolver.init_default(512, &ir).unwrap();
+
+let input = vec![1.0_f32; 512];
+let mut output = vec![0.0_f32; 512];
+convolver.process(&input, &mut output).unwrap();
+```
+
+Or control both block sizes explicitly via `init(head_block_size, tail_block_size, &ir)`.
+
 ### Handling Stream Discontinuities
 
 ```rust
@@ -87,15 +106,34 @@ convolver.process(&input, &mut output).unwrap();
 - **Impulse response length**: Longer IRs require more computation. The algorithm scales well with IR length.
 - **Buffer size**: Any input/output size is supported efficiently through internal buffering.
 
+## Benchmarks
+
+Run the benchmarks yourself with:
+
+```sh
+cargo bench
+```
+
+Results on AMD Ryzen 9900X (CachyOS, x86-64):
+
+| IR length | `FFTConvolver` | `TwoStageFFTConvolver` | speedup |
+|---|---|---|---|
+| 4 096 | 3.70 µs | 5.87 µs | −1.6× (slower) |
+| 16 384 | 10.93 µs | 10.03 µs | **1.1×** |
+| 65 536 | 40.82 µs | 16.13 µs | **2.5×** |
+| 131 072 | 81.8 µs | 18.6 µs | **4.4×** |
+
+`FFTConvolver` is faster for short IRs. `TwoStageFFTConvolver` becomes faster from ~16k samples onward, with the advantage growing significantly at longer IR lengths.
+
 ## Real-Time Safety
 
-The following operations are real-time safe (no allocations):
+The following operations are real-time safe (no allocations) on both `FFTConvolver` and `TwoStageFFTConvolver`:
 - `process()` - Audio processing
 - `set_response()` - Updating impulse response
 - `reset()` - Clearing internal state
 
 The following operations are NOT real-time safe (perform allocations):
-- `init()` - Initial setup
+- `init()` / `init_default()` - Initial setup
 
 ## License
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,13 @@
 
 - **Stale buffer data on re-initialization**: Calling `init()` on an already-initialized convolver now clears all internal state, preventing leftover data from a previous session from appearing in the output.
 
-## Improvements
+- **`process()` now returns an error on mismatched buffer lengths**: Passing `input` and `output` slices of different lengths previously caused a panic. It now returns `FFTConvolverError::InputOutputLengthMismatch`.
+
+- **Stale segment history after `set_response()`**: The internal FFT'd input history (`segments[]`) was not cleared when calling `set_response()`, leaving residual state that could affect subsequent output. It is now fully zeroed alongside the other buffers.
+
+- **Inefficient loop unrolling in `sum()`**: The 4×-unrolled loop processed only ¾ of the aligned elements. Results were always correct but the unrolling did less work than intended.
+
+## Chores
 
 - **Minimum Rust version**: Updated from 1.85 to 1.87.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,25 +1,17 @@
 # Release Notes
 
-## Breaking Changes
+## New Features
 
-- **`reset()` is now `nonblocking` and preserves configuration**: The `reset()` function now only clears the internal processing state (buffers, overlap, history) while preserving the impulse response configuration. Previously it reset the entire convolver. This makes it suitable for handling stream discontinuities (seeking, pause/resume) in real-time audio threads.
+- **`TwoStageFFTConvolver`**: A new convolver using non-uniform block sizes — a small "head" block for low-latency processing of the early IR and a large "tail" block for efficient processing of the late IR. Significantly faster than `FFTConvolver` for long impulse responses (2.5× at 65k samples, 4.4× at 131k samples). Use `init_default(block_size, &ir)` to let the library compute the optimal tail block size automatically, or `init(head_block_size, tail_block_size, &ir)` for full control.
 
-- **Consolidated error types**: `FFTConvolverInitError` and `FFTConvolverProcessError` have been merged into a single `FFTConvolverError` enum for simpler error handling.
+- **`Debug` derive on public types**: `FFTConvolver` and `TwoStageFFTConvolver` now derive `Debug`.
 
-- **New `set_response()` function**: Added a real-time safe method to update the impulse response without reallocating memory. The new impulse response must not exceed the length of the original one used during initialization. This enables dynamic IR changes in real-time applications.
+## Bug Fixes
+
+- **Stale buffer data on re-initialization**: Calling `init()` on an already-initialized convolver now clears all internal state, preventing leftover data from a previous session from appearing in the output.
 
 ## Improvements
 
-- **Real-time safety verification**: The `process()`, `set_response()`, and `reset()` functions are now validated by Realtime Sanitizer to ensure they perform no allocations or blocking operations.
-
-- **`Clone` implementation**: `FFTConvolver` now derives `Clone`, enabling usage in vectors and other collections (thanks @piedoom).
-
-- **Enhanced test coverage**: Added comprehensive tests for `reset()`, `set_response()`, zero-latency verification, and state management.
-
-- **Documentation overhaul**: Complete API documentation with examples, performance considerations, and real-time safety guarantees. Added module-level documentation explaining the partitioned FFT convolution algorithm.
-
-- **Rust Edition 2024**: Updated to Rust Edition 2024.
+- **Minimum Rust version**: Updated from 1.85 to 1.87.
 
 - **Dependency updates**: All dependencies updated to their latest versions.
-
-- **CI/CD pipeline**: Added continuous integration for automated testing and quality assurance.

--- a/benches/convolver.rs
+++ b/benches/convolver.rs
@@ -1,0 +1,39 @@
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use fft_convolver::{FFTConvolver, TwoStageFFTConvolver};
+
+const BLOCK_SIZE: usize = 512;
+const IR_LENGTHS: &[usize] = &[4_096, 16_384, 65_536, 131_072];
+
+fn make_ir(len: usize) -> Vec<f32> {
+    (0..len).map(|i| 1.0 / (i as f32 + 1.0)).collect()
+}
+
+fn bench_convolvers(c: &mut Criterion) {
+    let input = vec![0.5_f32; BLOCK_SIZE];
+    let mut output = vec![0.0_f32; BLOCK_SIZE];
+
+    let mut group = c.benchmark_group("convolver");
+
+    for &ir_len in IR_LENGTHS {
+        let ir = make_ir(ir_len);
+
+        let mut conv = FFTConvolver::<f32>::default();
+        conv.init(BLOCK_SIZE, &ir).unwrap();
+        group.bench_with_input(BenchmarkId::new("FFTConvolver", ir_len), &ir_len, |b, _| {
+            b.iter(|| conv.process(&input, &mut output).unwrap())
+        });
+
+        let mut conv = TwoStageFFTConvolver::<f32>::default();
+        conv.init_default(BLOCK_SIZE, &ir).unwrap();
+        group.bench_with_input(
+            BenchmarkId::new("TwoStageFFTConvolver", ir_len),
+            &ir_len,
+            |b, _| b.iter(|| conv.process(&input, &mut output).unwrap()),
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_convolvers);
+criterion_main!(benches);

--- a/examples/highpass_playback.rs
+++ b/examples/highpass_playback.rs
@@ -1,0 +1,124 @@
+use audio_blocks::Planar;
+use audio_host::{AudioBackend, AudioBlock, AudioBlockOpsMut, Config, Error};
+use fft_convolver::FFTConvolver;
+
+const SAMPLE_RATE: u32 = 48_000;
+const BLOCK_SIZE: usize = 1024;
+const NUM_CHANNELS: u16 = 2;
+const CUTOFF_HZ: f32 = 500.0;
+const NUM_TAPS: usize = 1023;
+
+fn highpass_fir(cutoff_hz: f32, sample_rate: f32, num_taps: usize) -> Vec<f32> {
+    let fc = cutoff_hz / sample_rate;
+    let m = num_taps - 1;
+    let center = m as f32 / 2.0;
+    let pi = std::f32::consts::PI;
+
+    let mut h: Vec<f32> = (0..num_taps)
+        .map(|n| {
+            let x = n as f32 - center;
+            let window = 0.5 * (1.0 - (2.0 * pi * n as f32 / m as f32).cos());
+            let sinc = if x.abs() < 1e-6 {
+                2.0 * fc
+            } else {
+                (2.0 * pi * fc * x).sin() / (pi * x)
+            };
+            sinc * window
+        })
+        .collect();
+
+    // Spectral inversion: highpass = delta - lowpass
+    h.iter_mut().for_each(|s| *s = -*s);
+    h[m / 2] += 1.0;
+    h
+}
+
+fn main() -> Result<(), Error> {
+    let path = std::env::args().nth(1).unwrap_or_else(|| {
+        eprintln!("Usage: highpass_playback <audio-file>");
+        std::process::exit(1);
+    });
+
+    let audio = audio_file::read::<f32>(
+        &path,
+        audio_file::ReadConfig {
+            sample_rate: Some(SAMPLE_RATE),
+            num_channels: Some(NUM_CHANNELS as usize),
+            ..Default::default()
+        },
+    )
+    .unwrap_or_else(|e| {
+        eprintln!("Failed to read audio file: {e}");
+        std::process::exit(1);
+    });
+
+    let num_frames_total = audio.samples_interleaved.len() / NUM_CHANNELS as usize;
+    let duration_secs = num_frames_total as f64 / SAMPLE_RATE as f64;
+    let tail_secs = BLOCK_SIZE as f64 / SAMPLE_RATE as f64;
+
+    println!(
+        "Playing '{}' ({:.1}s) with {CUTOFF_HZ} Hz highpass filter...",
+        path, duration_secs
+    );
+
+    let ir = highpass_fir(CUTOFF_HZ, SAMPLE_RATE as f32, NUM_TAPS);
+
+    let mut convolvers: Vec<FFTConvolver<f32>> = (0..NUM_CHANNELS)
+        .map(|_| {
+            let mut c = FFTConvolver::default();
+            c.init(BLOCK_SIZE, &ir).expect("convolver init failed");
+            c
+        })
+        .collect();
+
+    let mut input_block = Planar::<f32>::new(NUM_CHANNELS, BLOCK_SIZE);
+    let mut output_block = Planar::<f32>::new(NUM_CHANNELS, BLOCK_SIZE);
+    let audio_data = audio.samples_interleaved;
+    let mut pos = 0usize;
+
+    let mut host = audio_host::AudioHost::new()?;
+
+    host.start(
+        Config {
+            num_input_channels: 0,
+            num_output_channels: NUM_CHANNELS,
+            sample_rate: SAMPLE_RATE,
+            num_frames: BLOCK_SIZE,
+        },
+        move |_input, mut output| {
+            let num_frames = output.num_frames() as usize;
+            let num_ch = output.num_channels() as usize;
+
+            for ch in 0..num_ch {
+                let in_ch = input_block.channel_mut(ch as u16);
+                for f in 0..num_frames {
+                    let idx = (pos + f) * num_ch + ch;
+                    in_ch[f] = if idx < audio_data.len() {
+                        audio_data[idx]
+                    } else {
+                        0.0
+                    };
+                }
+                convolvers[ch]
+                    .process(
+                        input_block.channel(ch as u16),
+                        output_block.channel_mut(ch as u16),
+                    )
+                    .expect("process failed");
+            }
+
+            output.copy_from_block_exact(&output_block);
+
+            pos += num_frames;
+        },
+    )?;
+
+    std::thread::sleep(std::time::Duration::from_secs_f64(
+        duration_secs + tail_secs,
+    ));
+
+    host.stop()?;
+    println!("Done.");
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,8 @@ pub enum FFTConvolverError {
     BlockSizeZero,
     #[error("impulse response exceeds configured capacity")]
     ImpulseResponseExceedsCapacity,
+    #[error("input and output buffers must have the same length")]
+    InputOutputLengthMismatch,
     #[error("error in fft: {0}")]
     Fft(#[from] FftError),
 }
@@ -246,16 +248,18 @@ impl<F: FftNum> FFTConvolver<F> {
         self.input_buffer.fill(F::zero());
         self.input_buffer_fill = 0;
         self.current = 0;
+        for segment in &mut self.segments {
+            segment.fill(Complex::zero());
+        }
 
         Ok(())
     }
 
     /// Convolves the input samples with the impulse response and outputs the result
     ///
-    /// This is a real-time safe operation that performs no allocations. The input and
-    /// output buffers can be of any length. Internal buffering handles arbitrary sizes
-    /// and ensures the output is always properly aligned with the input (zero latency
-    /// except for processing time).
+    /// This is a real-time safe operation that performs no allocations. Internal buffering
+    /// handles arbitrary sizes and ensures the output is always properly aligned with the
+    /// input (zero latency except for processing time).
     ///
     /// If the convolver has no active impulse response, the output is filled with zeros.
     ///
@@ -266,6 +270,7 @@ impl<F: FftNum> FFTConvolver<F> {
     ///
     /// # Returns
     ///
+    /// Returns `InputOutputLengthMismatch` if `input` and `output` have different lengths.
     /// Returns `Fft` error if an FFT operation fails.
     ///
     /// # Example
@@ -283,6 +288,10 @@ impl<F: FftNum> FFTConvolver<F> {
     /// ```
     #[nonblocking]
     pub fn process(&mut self, input: &[F], output: &mut [F]) -> Result<(), FFTConvolverError> {
+        if input.len() != output.len() {
+            return Err(FFTConvolverError::InputOutputLengthMismatch);
+        }
+
         if self.active_seg_count == 0 {
             output.fill(F::zero());
             return Ok(());
@@ -744,6 +753,21 @@ mod tests {
     }
 
     #[test]
+    fn process_mismatched_lengths_returns_error() {
+        let mut convolver = FFTConvolver::<f32>::default();
+        let ir = vec![1., 0., 0., 0.];
+        convolver.init(4, &ir).unwrap();
+
+        let input = vec![1.0; 4];
+        let mut output = vec![0.0; 8];
+        let result = convolver.process(&input, &mut output);
+        assert!(matches!(
+            result.unwrap_err(),
+            FFTConvolverError::InputOutputLengthMismatch
+        ));
+    }
+
+    #[test]
     fn reinit_with_empty_ir_produces_silence() {
         let long_ir = vec![0.5_f32; 1000];
         let block_size = 4;
@@ -762,6 +786,51 @@ mod tests {
                 "Expected silence at index {}, got {}",
                 i,
                 sample
+            );
+        }
+    }
+
+    #[test]
+    fn test_block_size_one() {
+        let mut convolver = FFTConvolver::<f32>::default();
+        let ir = vec![0.5_f32, 0.3, 0.2, 0.1];
+        convolver.init(1, &ir).unwrap();
+        assert_eq!(convolver.block_size, 1);
+
+        let mut input = vec![0.0_f32; 16];
+        input[0] = 1.0;
+        let mut output = vec![0.0_f32; 16];
+        convolver.process(&input, &mut output).unwrap();
+
+        assert!((output[0] - 0.5).abs() < 1e-5);
+        assert!((output[1] - 0.3).abs() < 1e-5);
+        assert!((output[2] - 0.2).abs() < 1e-5);
+        assert!((output[3] - 0.1).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_large_ir() {
+        // IR longer than a single block; verify output matches expectations over many segments
+        let ir_len = 8192_usize;
+        let block_size = 512;
+
+        let mut ir = vec![0.0_f32; ir_len];
+        ir[0] = 1.0; // identity
+
+        let mut convolver = FFTConvolver::<f32>::default();
+        convolver.init(block_size, &ir).unwrap();
+
+        let input: Vec<f32> = (0..ir_len).map(|i| i as f32 * 0.001).collect();
+        let mut output = vec![0.0_f32; ir_len];
+        convolver.process(&input, &mut output).unwrap();
+
+        for i in 0..ir_len {
+            assert!(
+                (output[i] - input[i]).abs() < 1e-4,
+                "Mismatch at {}: input={}, output={}",
+                i,
+                input[i],
+                output[i]
             );
         }
     }

--- a/src/two_stage.rs
+++ b/src/two_stage.rs
@@ -370,7 +370,7 @@ impl<F: FftNum> TwoStageFFTConvolver<F> {
 
             // Process tail0 incrementally (every head_block_size samples)
             if !self.tail_precalculated0.is_empty()
-                && self.tail_input_fill % self.head_block_size == 0
+                && self.tail_input_fill.is_multiple_of(self.head_block_size)
             {
                 let block_offset = self.tail_input_fill - self.head_block_size;
                 self.processing_buffer[..self.head_block_size].copy_from_slice(

--- a/src/two_stage.rs
+++ b/src/two_stage.rs
@@ -287,10 +287,9 @@ impl<F: FftNum> TwoStageFFTConvolver<F> {
 
     /// Convolves the input samples with the impulse response and outputs the result
     ///
-    /// This is a real-time safe operation that performs no allocations. The input and
-    /// output buffers can be of any length. Internal buffering handles arbitrary sizes
-    /// and ensures the output is always properly aligned with the input (zero latency
-    /// except for processing time).
+    /// This is a real-time safe operation that performs no allocations. Internal buffering
+    /// handles arbitrary sizes and ensures the output is always properly aligned with the
+    /// input (zero latency except for processing time).
     ///
     /// # Arguments
     ///
@@ -299,6 +298,7 @@ impl<F: FftNum> TwoStageFFTConvolver<F> {
     ///
     /// # Returns
     ///
+    /// Returns `InputOutputLengthMismatch` if `input` and `output` have different lengths.
     /// Returns `Fft` error if an FFT operation fails.
     ///
     /// # Example
@@ -319,6 +319,9 @@ impl<F: FftNum> TwoStageFFTConvolver<F> {
     /// ```
     #[nonblocking]
     pub fn process(&mut self, input: &[F], output: &mut [F]) -> Result<(), FFTConvolverError> {
+        if input.len() != output.len() {
+            return Err(FFTConvolverError::InputOutputLengthMismatch);
+        }
         self.head_convolver.process(input, output)?;
 
         if self.tail_input.is_empty() {
@@ -819,6 +822,21 @@ mod tests {
     }
 
     #[test]
+    fn process_mismatched_lengths_returns_error() {
+        let mut convolver = TwoStageFFTConvolver::<f32>::default();
+        let ir = vec![0.5; 10000];
+        convolver.init(64, 4096, &ir).unwrap();
+
+        let input = vec![1.0_f32; 64];
+        let mut output = vec![0.0_f32; 128];
+        let result = convolver.process(&input, &mut output);
+        assert!(matches!(
+            result.unwrap_err(),
+            FFTConvolverError::InputOutputLengthMismatch
+        ));
+    }
+
+    #[test]
     fn test_short_ir_degenerate() {
         // IR shorter than head block — should behave like plain FFTConvolver
         let ir = vec![0.5, 0.3, 0.2, 0.1];
@@ -843,6 +861,57 @@ mod tests {
                 i,
                 output_uniform[i],
                 output_two_stage[i]
+            );
+        }
+    }
+
+    #[test]
+    fn test_small_head_block_size() {
+        // head_block_size=1 (rounds to 1); ensures no off-by-one in buffering
+        let ir = vec![0.5_f32, 0.3, 0.2, 0.1];
+        let mut convolver = TwoStageFFTConvolver::<f32>::default();
+        convolver.init(1, 16, &ir).unwrap();
+        assert_eq!(convolver.head_block_size, 1);
+
+        let mut input = vec![0.0_f32; 16];
+        input[0] = 1.0;
+        let mut output = vec![0.0_f32; 16];
+        convolver.process(&input, &mut output).unwrap();
+
+        assert!((output[0] - 0.5).abs() < 1e-5);
+        assert!((output[1] - 0.3).abs() < 1e-5);
+        assert!((output[2] - 0.2).abs() < 1e-5);
+        assert!((output[3] - 0.1).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_large_ir_equivalence() {
+        // Long IR — all three convolver stages active; compare against uniform convolver
+        let ir_len = 16384_usize;
+        let mut ir = vec![0.0_f32; ir_len];
+        ir[0] = 1.0; // identity
+
+        let mut uniform = FFTConvolver::<f32>::default();
+        uniform.init(512, &ir).unwrap();
+
+        let tail_block_size = compute_tail_block_size(512, ir_len);
+        let mut two_stage = TwoStageFFTConvolver::<f32>::default();
+        two_stage.init(512, tail_block_size, &ir).unwrap();
+
+        let input: Vec<f32> = (0..2048).map(|i| (i as f32 * 0.01).sin()).collect();
+        let mut out_uniform = vec![0.0_f32; 2048];
+        let mut out_two_stage = vec![0.0_f32; 2048];
+
+        uniform.process(&input, &mut out_uniform).unwrap();
+        two_stage.process(&input, &mut out_two_stage).unwrap();
+
+        for i in 0..input.len() {
+            assert!(
+                (out_uniform[i] - out_two_stage[i]).abs() < 1e-3,
+                "Mismatch at {}: uniform={}, two_stage={}",
+                i,
+                out_uniform[i],
+                out_two_stage[i]
             );
         }
     }

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -76,7 +76,7 @@ pub fn sum<F: FftNum>(result: &mut [F], a: &[F], b: &[F]) {
     assert_eq!(result.len(), a.len());
     assert_eq!(result.len(), b.len());
     let len = result.len();
-    let end4 = 3 * (len / 4);
+    let end4 = 4 * (len / 4);
     #[allow(clippy::identity_op)]
     for i in (0..end4).step_by(4) {
         result[i + 0] = a[i + 0] + b[i + 0];


### PR DESCRIPTION
## New Features

- **`TwoStageFFTConvolver`**: A new convolver using non-uniform block sizes — a small "head" block for low-latency processing of the early IR and a large "tail" block for efficient processing of the late IR. Significantly faster than `FFTConvolver` for long impulse responses (2.5× at 65k samples, 4.4× at 131k samples). Use `init_default(block_size, &ir)` to let the library compute the optimal tail block size automatically, or `init(head_block_size, tail_block_size, &ir)` for full control.

- **`Debug` derive on public types**: `FFTConvolver` and `TwoStageFFTConvolver` now derive `Debug`.

## Bug Fixes

- **Stale buffer data on re-initialization**: Calling `init()` on an already-initialized convolver now clears all internal state, preventing leftover data from a previous session from appearing in the output.

- **`process()` now returns an error on mismatched buffer lengths**: Passing `input` and `output` slices of different lengths previously caused a panic. It now returns `FFTConvolverError::InputOutputLengthMismatch`.

- **Stale segment history after `set_response()`**: The internal FFT'd input history (`segments[]`) was not cleared when calling `set_response()`, leaving residual state that could affect subsequent output. It is now fully zeroed alongside the other buffers.

- **Inefficient loop unrolling in `sum()`**: The 4×-unrolled loop processed only ¾ of the aligned elements. Results were always correct but the unrolling did less work than intended.

## Chores

- **Minimum Rust version**: Updated from 1.85 to 1.87.

- **Dependency updates**: All dependencies updated to their latest versions.
